### PR TITLE
Master issue30

### DIFF
--- a/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeAADLConnection.java
+++ b/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeAADLConnection.java
@@ -4,6 +4,8 @@ import org.eclipse.emf.ecore.EObject;
 
 import com.rockwellcollins.atc.agree.analysis.ast.visitors.AgreeASTVisitor;
 
+import jkind.Assert;
+
 public class AgreeAADLConnection implements AgreeConnection {
 
 	public enum ConnectionType {
@@ -22,6 +24,9 @@ public class AgreeAADLConnection implements AgreeConnection {
 	public AgreeAADLConnection(AgreeNode sourceNode, AgreeNode destinationNode, AgreeVar sourceVarName,
 			AgreeVar destinationVarName, ConnectionType type, boolean latched, boolean delayed, EObject reference) {
 
+		Assert.isNotNull(sourceVarName);
+		Assert.isNotNull(destinationVarName);
+		Assert.isNotNull(type);
 		this.sourceNode = sourceNode;
 		this.destinationNode = destinationNode;
 		this.sourceVarName = sourceVarName;
@@ -38,4 +43,19 @@ public class AgreeAADLConnection implements AgreeConnection {
 		return null;
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		if (other instanceof AgreeAADLConnection) {
+			AgreeAADLConnection otherAgreeAADLConnection = (AgreeAADLConnection) other;
+			return ((sourceNode == null && otherAgreeAADLConnection.sourceNode == null)
+					|| sourceNode.equals(otherAgreeAADLConnection.sourceNode))
+					&& ((destinationNode == null && otherAgreeAADLConnection.destinationNode == null)
+							|| destinationNode.equals(otherAgreeAADLConnection.destinationNode))
+					&& sourceVarName.equals(otherAgreeAADLConnection.sourceVarName)
+					&& destinationVarName.equals(otherAgreeAADLConnection.destinationVarName)
+					&& type.equals(otherAgreeAADLConnection.type) && latched == otherAgreeAADLConnection.latched
+					&& delayed == otherAgreeAADLConnection.delayed;
+		}
+		return false;
+	}
 }

--- a/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeASTBuilder.java
+++ b/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeASTBuilder.java
@@ -49,6 +49,7 @@ import org.osate.aadl2.Subcomponent;
 import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.ConnectionInstance;
 import org.osate.aadl2.instance.ConnectionInstanceEnd;
+import org.osate.aadl2.instance.ConnectionReference;
 import org.osate.aadl2.instance.FeatureCategory;
 import org.osate.aadl2.instance.FeatureInstance;
 import org.osate.aadl2.modelsupport.scoping.Aadl2GlobalScopeUtil;
@@ -367,7 +368,9 @@ public class AgreeASTBuilder extends AgreeSwitch<Expr> {
 
 			}
 
-			EList<ConnectionInstance> connectionInstances = compInst.getConnectionInstances();
+			EList<ConnectionInstance> connectionInstances = compInst.getAllEnclosingConnectionInstances();
+			List<ConnectionInstance> foo = new ArrayList<>();
+			compInst.getAllComponentInstances().forEach(ci -> ci.allEnclosingConnectionInstances().forEach(foo::add));
 			aadlConnections.addAll(getConnectionsFromInstances(connectionInstances, compInst, subNodes, latched));
 			connections.addAll(filterConnections(aadlConnections, userDefinedConections));
 
@@ -807,116 +810,122 @@ public class AgreeASTBuilder extends AgreeSwitch<Expr> {
 			ComponentInstance compInst, List<AgreeNode> subnodes, boolean latched) {
 		List<AgreeAADLConnection> result = new ArrayList<>();
 		for (ConnectionInstance connectionInstance : connectionInstances) {
-			ConnectionInstanceEnd sourceEndInstance = connectionInstance.getSource();
-			ConnectionInstanceEnd destinationEndInstance = connectionInstance.getDestination();
-			ComponentInstance sourceComponentInstance = sourceEndInstance.getComponentInstance();
-			ComponentInstance destinationComponentInstance = destinationEndInstance.getComponentInstance();
-
-			// make connections only to subcomponents that have annexes
-			if (!compInst.equals(sourceComponentInstance)
-					&& compInst.getAllComponentInstances().contains(sourceComponentInstance)) {
-				if (!AgreeUtils.containsTransitiveAgreeAnnex(sourceComponentInstance, isMonolithic)) {
-					continue;
-				}
-			}
-			if (!compInst.equals(destinationComponentInstance)
-					&& compInst.getAllComponentInstances().contains(destinationComponentInstance)) {
-				if (!AgreeUtils.containsTransitiveAgreeAnnex(destinationComponentInstance, isMonolithic)) {
-					continue;
-				}
-			}
 
 			boolean isDelayed = isDelayed(connectionInstance, compInst);
 
-			AgreeNode sourceNode = agreeNodeFromNamedEl(subnodes, sourceComponentInstance);
-			AgreeNode destinationNode = agreeNodeFromNamedEl(subnodes, destinationComponentInstance);
+			for (ConnectionReference connectionReference : connectionInstance.getConnectionReferences()) {
 
-			ConnectionEnd sourceConnectionEnd;
-			if (sourceEndInstance instanceof FeatureInstance) {
-				sourceConnectionEnd = ((FeatureInstance) sourceEndInstance).getFeature();
-			} else {
-				AgreeLogger.logWarning("unable to reason about connection '" + connectionInstance.getQualifiedName()
-						+ "' because it connects from a " + sourceEndInstance.getClass().getName());
-				continue;
-			}
+				ConnectionInstanceEnd sourceEndInstance = connectionReference.getSource();
+				ConnectionInstanceEnd destinationEndInstance = connectionReference.getDestination();
 
-			ConnectionEnd destinationConnectionEnd;
-			if (destinationEndInstance instanceof FeatureInstance) {
-				destinationConnectionEnd = ((FeatureInstance) destinationEndInstance).getFeature();
-			} else {
-				AgreeLogger.logWarning("unable to reason about connection '" + connectionInstance.getQualifiedName()
-						+ "' because it connects to a " + destinationEndInstance.getClass().getName());
-				continue;
-			}
+				ComponentInstance sourceComponentInstance = sourceEndInstance.getComponentInstance();
+				ComponentInstance destinationComponentInstance = destinationEndInstance.getComponentInstance();
 
-			if (sourceConnectionEnd instanceof DataSubcomponent
-					|| destinationConnectionEnd instanceof DataSubcomponent) {
-				AgreeLogger.logWarning("unable to reason about connection '" + connectionInstance.getQualifiedName()
-						+ "' because it connects to a data subcomponent");
-				continue;
-			}
-
-			// Handle prefixing elements of feature groups
-			String sourcePrefix = null;
-			if (sourceConnectionEnd instanceof FeatureGroup) {
-				sourcePrefix = sourceConnectionEnd.getName();
-			}
-			String destinationPrefix = null;
-			if (destinationConnectionEnd instanceof FeatureGroup) {
-				destinationPrefix = destinationConnectionEnd.getName();
-			}
-
-			List<AgreeVar> sourceVars = getAgreePortNames(sourceConnectionEnd,
-					sourcePrefix,
-					sourceNode == null ? null : sourceNode.compInst);
-			List<AgreeVar> destinationVars = getAgreePortNames(destinationConnectionEnd,
-					destinationPrefix,
-					destinationNode == null ? null : destinationNode.compInst);
-
-			if (sourceVars.size() != destinationVars.size()) {
-				throw new AgreeException("The number of AGREE variables differ for connection '"
-						+ connectionInstance.getQualifiedName()
-						+ "'. Do the types of the source and destination differ? Perhaps one is an implementation and the other is a type?");
-			}
-
-			for (int i = 0; i < sourceVars.size(); i++) {
-				AgreeVar sourceVar = sourceVars.get(i);
-				AgreeVar destinationVar = destinationVars.get(i);
-
-				if (!matches((ConnectionEnd) sourceVar.reference, (ConnectionEnd) destinationVar.reference)) {
-					AgreeLogger.logWarning("Connection '" + connectionInstance.getQualifiedName() + "' has ports '"
-							+ sourceVar.id.replace(dotChar, ".") + "' and '" + destinationVar.id.replace(dotChar, ".")
-							+ "' of differing type");
+				if (!compInst.equals(sourceComponentInstance)
+						&& !compInst.getComponentInstances().contains(sourceComponentInstance)) {
+					// This connection reference connects to component instances not germane to this level of hierarchy
+					continue;
+				}
+				if (!compInst.equals(destinationComponentInstance)
+						&& !compInst.getComponentInstances().contains(destinationComponentInstance)) {
+					// This connection reference connects to component instances not germane to this level of hierarchy
 					continue;
 				}
 
-				if (!sourceVar.type.equals(destinationVar.type)) {
-					throw new AgreeException("Type mismatch during connection generation");
+				// make connections only to subcomponents that have annexes
+				if (!compInst.equals(sourceComponentInstance)
+						&& compInst.getAllComponentInstances().contains(sourceComponentInstance)) {
+					if (!AgreeUtils.containsTransitiveAgreeAnnex(sourceComponentInstance, isMonolithic)) {
+						continue;
+					}
+				}
+				if (!compInst.equals(destinationComponentInstance)
+						&& compInst.getAllComponentInstances().contains(destinationComponentInstance)) {
+					if (!AgreeUtils.containsTransitiveAgreeAnnex(destinationComponentInstance, isMonolithic)) {
+						continue;
+					}
 				}
 
-				ConnectionType connType;
+				AgreeNode sourceNode = agreeNodeFromNamedEl(subnodes, sourceComponentInstance);
+				AgreeNode destinationNode = agreeNodeFromNamedEl(subnodes, destinationComponentInstance);
 
-				if (sourceVar.id.endsWith(eventSuffix)) {
-					connType = ConnectionType.EVENT;
+				ConnectionEnd sourceConnectionEnd;
+				if (sourceEndInstance instanceof FeatureInstance) {
+					sourceConnectionEnd = ((FeatureInstance) sourceEndInstance).getFeature();
 				} else {
-					connType = ConnectionType.DATA;
+					AgreeLogger.logWarning("unable to reason about connection '" + connectionInstance.getQualifiedName()
+							+ "' because it connects from a " + sourceEndInstance.getClass().getName());
+					continue;
 				}
 
-				// TODO: connection instances may span multiple connections transiting multiple layers of hierarchy.
-				// Handle this stepwise by making an AGREE AADL connection for each step?
-				if (connectionInstance.getConnectionReferences().size() != 1) {
-					throw new AgreeException(
-							"Connection instances must reference exactly one connection.  Found connection instance"
-									+ connectionInstance.getFullName() + " in "
-									+ connectionInstance.getContainingClassifier().getQualifiedName() + " refers to "
-									+ connectionInstance.getConnectionReferences().size() + " connections."
-									+ " Perhaps it connects across multiple layers of hierarchy?");
+				ConnectionEnd destinationConnectionEnd;
+				if (destinationEndInstance instanceof FeatureInstance) {
+					destinationConnectionEnd = ((FeatureInstance) destinationEndInstance).getFeature();
+				} else {
+					AgreeLogger.logWarning("unable to reason about connection '" + connectionInstance.getQualifiedName()
+							+ "' because it connects to a " + destinationEndInstance.getClass().getName());
+					continue;
 				}
-				AgreeAADLConnection agreeConnection = new AgreeAADLConnection(sourceNode, destinationNode, sourceVar,
-						destinationVar, connType, latched, isDelayed,
-						connectionInstance.getConnectionReferences().get(0).getConnection());
 
-				result.add(agreeConnection);
+				// TODO: Paranoia? Is this redundant with the previous lines?
+				if (sourceConnectionEnd instanceof DataSubcomponent
+						|| destinationConnectionEnd instanceof DataSubcomponent) {
+					AgreeLogger.logWarning("unable to reason about connection '" + connectionInstance.getQualifiedName()
+							+ "' because it connects to a data subcomponent");
+					continue;
+				}
+
+				// Handle prefixing elements of feature groups
+				String sourcePrefix = null;
+				if (sourceConnectionEnd instanceof FeatureGroup) {
+					sourcePrefix = sourceConnectionEnd.getName();
+				}
+				String destinationPrefix = null;
+				if (destinationConnectionEnd instanceof FeatureGroup) {
+					destinationPrefix = destinationConnectionEnd.getName();
+				}
+
+				List<AgreeVar> sourceVars = getAgreePortNames(sourceConnectionEnd, sourcePrefix,
+						sourceNode == null ? null : sourceNode.compInst);
+				List<AgreeVar> destinationVars = getAgreePortNames(destinationConnectionEnd, destinationPrefix,
+						destinationNode == null ? null : destinationNode.compInst);
+
+				if (sourceVars.size() != destinationVars.size()) {
+					throw new AgreeException("The number of AGREE variables differ for connection '"
+							+ connectionInstance.getQualifiedName()
+							+ "'. Do the types of the source and destination differ? Perhaps one is an implementation and the other is a type?");
+				}
+
+				for (int i = 0; i < sourceVars.size(); i++) {
+					AgreeVar sourceVar = sourceVars.get(i);
+					AgreeVar destinationVar = destinationVars.get(i);
+
+					if (!matches((ConnectionEnd) sourceVar.reference, (ConnectionEnd) destinationVar.reference)) {
+						AgreeLogger.logWarning("Connection '" + connectionInstance.getQualifiedName() + "' has ports '"
+								+ sourceVar.id.replace(dotChar, ".") + "' and '"
+								+ destinationVar.id.replace(dotChar, ".") + "' of differing type");
+						continue;
+					}
+
+					if (!sourceVar.type.equals(destinationVar.type)) {
+						throw new AgreeException("Type mismatch during connection generation");
+					}
+
+					ConnectionType connType;
+
+					if (sourceVar.id.endsWith(eventSuffix)) {
+						connType = ConnectionType.EVENT;
+					} else {
+						connType = ConnectionType.DATA;
+					}
+
+					AgreeAADLConnection agreeConnection = new AgreeAADLConnection(sourceNode, destinationNode,
+							sourceVar, destinationVar, connType, latched, isDelayed,
+							connectionInstance.getConnectionReferences().get(0).getConnection());
+
+					result.add(agreeConnection);
+				}
+
 			}
 
 		}

--- a/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeASTBuilder.java
+++ b/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/ast/AgreeASTBuilder.java
@@ -40,6 +40,7 @@ import org.osate.aadl2.FeatureGroupType;
 import org.osate.aadl2.IntegerLiteral;
 import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.NamedValue;
+import org.osate.aadl2.PortConnection;
 import org.osate.aadl2.Property;
 import org.osate.aadl2.PropertyConstant;
 import org.osate.aadl2.PropertyExpression;
@@ -514,7 +515,9 @@ public class AgreeASTBuilder extends AgreeSwitch<Expr> {
 					break;
 				}
 			}
-			conns.add(replacementConn);
+			if (!conns.contains(replacementConn)) {
+				conns.add(replacementConn);
+			}
 		}
 
 		// throw errors for non-override connections with multiple fanin
@@ -524,8 +527,12 @@ public class AgreeASTBuilder extends AgreeSwitch<Expr> {
 			if (conn instanceof AgreeAADLConnection) {
 				AgreeAADLConnection aadlConn = (AgreeAADLConnection) conn;
 				if (!destinations.add(aadlConn.destinationVarName)) {
-					String message = "Multiple connections to feature '" + aadlConn.destinationVarName + "'. Remove "
-							+ "the additional AADL connections or override them with a connection statement "
+					String message = "Multiple connections to feature '"
+							+ (aadlConn.reference instanceof PortConnection
+									? ((PortConnection) aadlConn.reference).getDestination().getConnectionEnd()
+											.getQualifiedName()
+									: aadlConn.destinationVarName)
+							+ "'. Remove the additional AADL connections or override them with a connection statement "
 							+ "in the AGREE annex.";
 					throw new AgreeException(message);
 				}

--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
@@ -83,7 +83,7 @@ class Issue30Test extends XtextTest {
 				features 
 					env_temp : in data port Integer;
 					temp_sensor_high : out data port Boolean;
-					pressure_sensor_high : out data port Boolean;
+					temp_read : out data port Integer;
 			
 				annex agree {**
 					assume "Temp bounded":
@@ -99,6 +99,7 @@ class Issue30Test extends XtextTest {
 				connections
 					temp_out : port env_temp -> sensors.env_temp;
 					temp_indicator : port sensors.temp_high -> temp_sensor_high;
+					temp_sensor_read : port sensors.temp_read -> temp_read;
 			
 				annex agree{**
 					lemma "The sensor only reports high when temp is actually high." :

--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
@@ -1,0 +1,127 @@
+package com.rockwellcollins.atc.agree.tests.issues
+
+import com.google.inject.Inject
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.eclipse.xtext.EcoreUtil2
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import com.itemis.xtext.testing.XtextTest
+
+import org.osate.aadl2.AadlPackage
+import org.osate.aadl2.ComponentImplementation
+import org.osate.aadl2.instantiation.InstantiateModel
+
+import com.rockwellcollins.atc.agree.analysis.ast.AgreeASTBuilder
+
+import com.rockwellcollins.atc.agree.tests.AgreeUiInjectorProvider
+import com.rockwellcollins.atc.agree.tests.testsupport.TestHelper
+import com.rockwellcollins.atc.agree.analysis.ast.AgreeAADLConnection
+
+@RunWith(XtextRunner)
+@InjectWith(AgreeUiInjectorProvider)
+class Issue30Test extends XtextTest {
+
+	@Inject
+	TestHelper<AadlPackage> testHelper
+
+	// @Inject
+	// extension AssertHelper
+	static val issue30TestModel = '''
+		package Issue30TestModel
+		public
+			with Base_Types;
+			renames Base_Types::all;
+		
+			system TempSensor
+				features
+					env_temp : in data port Integer;
+					high_temp_indicator : out data port Boolean;
+					temp_reading : out data port Integer;
+			
+				annex agree {**
+					assume "Temp bounded":
+						((env_temp > 0) and (env_temp < 10));
+		
+					guarantee "If temperature is high, output high indication.":
+						(((env_temp > 8) <=> high_temp_indicator) and (env_temp = temp_reading));
+				**};
+		
+			end TempSensor;
+		
+			system SensorSystem
+				features
+					env_temp : in data port Integer;
+					temp_read : out data port Integer;
+					temp_high : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						((env_temp > 0) and (env_temp < 10));
+		
+					guarantee "Temperature guarantee.":
+						(env_temp = temp_read) and ((env_temp > 8) <=> temp_high);
+				**};
+		
+			end SensorSystem;
+		
+			system implementation SensorSystem.impl
+				subcomponents
+					temp : system TempSensor;
+		
+				connections
+					temp_out : port env_temp -> temp.env_temp;
+					temp_sensor_read : port temp.temp_reading -> temp_read;
+					high_temp : port temp.high_temp_indicator -> temp_high;
+		
+			end SensorSystem.impl;
+		
+			system TopLevel
+				features 
+					env_temp : in data port Integer;
+					temp_sensor_high : out data port Boolean;
+					pressure_sensor_high : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						(env_temp > 0) and (env_temp < 10);
+				**};
+			
+			end TopLevel;
+		
+			system implementation TopLevel.impl
+				subcomponents
+					sensors: system SensorSystem.impl;
+		
+				connections
+					temp_out : port env_temp -> sensors.env_temp;
+					temp_indicator : port sensors.temp_high -> temp_sensor_high;
+			
+				annex agree{**
+					lemma "The sensor only reports high when temp is actually high." :
+						((env_temp > 8) <=> temp_sensor_high);
+				**};
+		
+			end TopLevel.impl;
+		
+		end Issue30TestModel;
+	'''
+
+	@Test(expected=Test.None /* no exception expected */)
+	def void issue30test1() {
+		val testResult = issues = testHelper.testString(
+			com.rockwellcollins.atc.agree.tests.issues.Issue30Test.issue30TestModel)
+
+		val topLevelImpl = EcoreUtil2.getAllContentsOfType(testResult.resource.contents.head, ComponentImplementation).
+			filter(
+				it |
+					"TopLevel.impl".equals(it.name)
+			).head
+		val componentInstance = InstantiateModel.instantiate(topLevelImpl)
+		new AgreeASTBuilder().getAgreeProgram(componentInstance, false)
+	}
+
+}

--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
@@ -20,6 +20,7 @@ import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter
 import com.rockwellcollins.atc.agree.analysis.ast.AgreeASTBuilder
 import com.rockwellcollins.atc.agree.tests.AgreeUiInjectorProvider
 import com.rockwellcollins.atc.agree.tests.testsupport.TestHelper
+import com.rockwellcollins.atc.agree.analysis.AgreeException
 
 @RunWith(XtextRunner)
 @InjectWith(AgreeUiInjectorProvider)
@@ -36,8 +37,6 @@ class Issue30Test extends XtextTest {
 		return (result -> instantiationMarkers)
 	}
 
-	// @Inject
-	// extension AssertHelper
 	static val issue30TestMissingConnectionModel = '''
 		package Issue30TestModel
 		public
@@ -132,8 +131,6 @@ class Issue30Test extends XtextTest {
 		Assert.assertTrue(errors.stream.anyMatch(msg|msg.message.contains("Could not continue connection from TopLevel_impl_Instance.sensors.temp.temp_reading ")))
 	}
 
-	// @Inject
-	// extension AssertHelper
 	static val issue30TestGoodConnectionModel = '''
 		package Issue30TestModel
 		public
@@ -228,6 +225,214 @@ class Issue30Test extends XtextTest {
 		val instanceWithErrors = instantiateWithErrorMessages(topLevelImpl)
 		val errors = instanceWithErrors.value
 		Assert.assertTrue(errors.empty)
+	}
+
+	static val issue30TestFanOutModel = '''
+		package Issue30TestModel
+		public
+			with Base_Types;
+			renames Base_Types::all;
+		
+			system TempSensor
+				features
+					env_temp : in data port Integer;
+					high_temp_indicator : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						((env_temp > 0) and (env_temp < 10));
+		
+					guarantee "If temperature is high, output high indication.":
+						((env_temp > 8) <=> high_temp_indicator);
+				**};
+		
+			end TempSensor;
+
+			system BooleanSink
+				features
+					inp : in data port Boolean;
+			end BooleanSink;
+		
+			system SensorSystem
+				features
+					env_temp : in data port Integer;
+					temp_high : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						((env_temp > 0) and (env_temp < 10));
+		
+					guarantee "Temperature guarantee.":
+						((env_temp > 8) <=> temp_high);
+				**};
+		
+			end SensorSystem;
+		
+			system implementation SensorSystem.impl
+				subcomponents
+					temp1 : system TempSensor;
+					temp2 : system TempSensor;
+					sink1 : system BooleanSink;
+					sink2 : system BooleanSink;
+		
+				connections
+					temp_out1 : port env_temp -> temp1.env_temp;
+					temp_out2 : port env_temp -> temp2.env_temp;
+					temp_sink1 : port temp1.high_temp_indicator -> sink1.inp;
+					temp_sink2 : port temp2.high_temp_indicator -> sink2.inp;
+		
+				annex agree {**
+					assign temp_high = (temp1.high_temp_indicator or temp2.high_temp_indicator);
+				**};
+			
+			end SensorSystem.impl;
+		
+			system TopLevel
+				features 
+					env_temp : in data port Integer;
+					temp_sensor_high : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						(env_temp > 0) and (env_temp < 10);
+				**};
+			
+			end TopLevel;
+		
+			system implementation TopLevel.impl
+				subcomponents
+					sensors: system SensorSystem.impl;
+		
+				connections
+					temp_out : port env_temp -> sensors.env_temp;
+					temp_indicator : port sensors.temp_high -> temp_sensor_high;
+			
+				annex agree{**
+					lemma "The sensor only reports high when temp is actually high." :
+						((env_temp > 8) <=> temp_sensor_high);
+				**};
+		
+			end TopLevel.impl;
+		
+		end Issue30TestModel;
+	'''
+
+	@Test(expected=Test.None /* no exception expected */)
+	def void issue30testFanOut() {
+		val testResult = issues = testHelper.testString(
+			com.rockwellcollins.atc.agree.tests.issues.Issue30Test.issue30TestFanOutModel)
+
+		val topLevelImpl = EcoreUtil2.getAllContentsOfType(testResult.resource.contents.head, ComponentImplementation).
+			filter(
+				it |
+					"TopLevel.impl".equals(it.name)
+			).head
+		val instanceWithErrors = instantiateWithErrorMessages(topLevelImpl)
+		val componentInstance = instanceWithErrors.key
+		val errors = instanceWithErrors.value
+		Assert.assertTrue(errors.empty)
+		new AgreeASTBuilder().getAgreeProgram(componentInstance, false)
+	}
+
+	static val issue30TestFanInModel = '''
+		package Issue30TestModel
+		public
+			with Base_Types;
+			renames Base_Types::all;
+		
+			system TempSensor
+				features
+					env_temp : in data port Integer;
+					high_temp_indicator : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						((env_temp > 0) and (env_temp < 10));
+		
+					guarantee "If temperature is high, output high indication.":
+						((env_temp > 8) <=> high_temp_indicator);
+				**};
+		
+			end TempSensor;
+		
+			system SensorSystem
+				features
+					env_temp : in data port Integer;
+					temp_high : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						((env_temp > 0) and (env_temp < 10));
+		
+					guarantee "Temperature guarantee.":
+						((env_temp > 8) <=> temp_high);
+				**};
+		
+			end SensorSystem;
+		
+			system implementation SensorSystem.impl
+				subcomponents
+					temp1 : system TempSensor;
+					temp2 : system TempSensor;
+		
+				connections
+					temp_out1 : port env_temp -> temp1.env_temp;
+					temp_out2 : port env_temp -> temp2.env_temp;
+					temp_high_out1 : port temp1.high_temp_indicator -> temp_high;
+					temp_high_out2 : port temp2.high_temp_indicator -> temp_high;
+		
+			end SensorSystem.impl;
+		
+			system TopLevel
+				features 
+					env_temp : in data port Integer;
+					temp_sensor_high : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						(env_temp > 0) and (env_temp < 10);
+				**};
+			
+			end TopLevel;
+		
+			system implementation TopLevel.impl
+				subcomponents
+					sensors: system SensorSystem.impl;
+		
+				connections
+					temp_out : port env_temp -> sensors.env_temp;
+					temp_indicator : port sensors.temp_high -> temp_sensor_high;
+			
+				annex agree{**
+					lemma "The sensor only reports high when temp is actually high." :
+						((env_temp > 8) <=> temp_sensor_high);
+				**};
+		
+			end TopLevel.impl;
+		
+		end Issue30TestModel;
+	'''
+
+	@Test(expected=AgreeException)
+	def void issue30testFanIn() {
+		val testResult = issues = testHelper.testString(
+			com.rockwellcollins.atc.agree.tests.issues.Issue30Test.issue30TestFanInModel)
+
+		val topLevelImpl = EcoreUtil2.getAllContentsOfType(testResult.resource.contents.head, ComponentImplementation).
+			filter(
+				it |
+					"TopLevel.impl".equals(it.name)
+			).head
+		val instanceWithErrors = instantiateWithErrorMessages(topLevelImpl)
+		val componentInstance = instanceWithErrors.key
+		val errors = instanceWithErrors.value
+		Assert.assertTrue(errors.empty)
+		try {
+			new AgreeASTBuilder().getAgreeProgram(componentInstance.componentInstances.head, false)
+		} catch (AgreeException e) {
+			Assert.assertTrue(e.message.contains("Multiple connections to feature 'Issue30TestModel::SensorSystem.temp_high'"))
+			throw e
+		}
 	}
 
 }

--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
@@ -14,12 +14,12 @@ import com.itemis.xtext.testing.XtextTest
 import org.osate.aadl2.AadlPackage
 import org.osate.aadl2.ComponentImplementation
 import org.osate.aadl2.instantiation.InstantiateModel
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter
 
 import com.rockwellcollins.atc.agree.analysis.ast.AgreeASTBuilder
-
 import com.rockwellcollins.atc.agree.tests.AgreeUiInjectorProvider
 import com.rockwellcollins.atc.agree.tests.testsupport.TestHelper
-import com.rockwellcollins.atc.agree.analysis.ast.AgreeAADLConnection
 
 @RunWith(XtextRunner)
 @InjectWith(AgreeUiInjectorProvider)
@@ -28,9 +28,113 @@ class Issue30Test extends XtextTest {
 	@Inject
 	TestHelper<AadlPackage> testHelper
 
+	def instantiateWithErrorMessages(ComponentImplementation ci) {
+		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
+		val result = InstantiateModel.instantiate(ci, errorManager)
+		val errorReporter = errorManager.getReporter(result.eResource()) as QueuingAnalysisErrorReporter
+		val instantiationMarkers = errorReporter.getErrors()
+		return (result -> instantiationMarkers)
+	}
+
 	// @Inject
 	// extension AssertHelper
-	static val issue30TestModel = '''
+	static val issue30TestMissingConnectionModel = '''
+		package Issue30TestModel
+		public
+			with Base_Types;
+			renames Base_Types::all;
+		
+			system TempSensor
+				features
+					env_temp : in data port Integer;
+					high_temp_indicator : out data port Boolean;
+					temp_reading : out data port Integer;
+			
+				annex agree {**
+					assume "Temp bounded":
+						((env_temp > 0) and (env_temp < 10));
+		
+					guarantee "If temperature is high, output high indication.":
+						(((env_temp > 8) <=> high_temp_indicator) and (env_temp = temp_reading));
+				**};
+		
+			end TempSensor;
+		
+			system SensorSystem
+				features
+					env_temp : in data port Integer;
+					temp_read : out data port Integer;
+					temp_high : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						((env_temp > 0) and (env_temp < 10));
+		
+					guarantee "Temperature guarantee.":
+						(env_temp = temp_read) and ((env_temp > 8) <=> temp_high);
+				**};
+		
+			end SensorSystem;
+		
+			system implementation SensorSystem.impl
+				subcomponents
+					temp : system TempSensor;
+		
+				connections
+					temp_out : port env_temp -> temp.env_temp;
+					temp_sensor_read : port temp.temp_reading -> temp_read;
+					high_temp : port temp.high_temp_indicator -> temp_high;
+		
+			end SensorSystem.impl;
+		
+			system TopLevel
+				features 
+					env_temp : in data port Integer;
+					temp_sensor_high : out data port Boolean;
+			
+				annex agree {**
+					assume "Temp bounded":
+						(env_temp > 0) and (env_temp < 10);
+				**};
+			
+			end TopLevel;
+		
+			system implementation TopLevel.impl
+				subcomponents
+					sensors: system SensorSystem.impl;
+		
+				connections
+					temp_out : port env_temp -> sensors.env_temp;
+					temp_indicator : port sensors.temp_high -> temp_sensor_high;
+			
+				annex agree{**
+					lemma "The sensor only reports high when temp is actually high." :
+						((env_temp > 8) <=> temp_sensor_high);
+				**};
+		
+			end TopLevel.impl;
+		
+		end Issue30TestModel;
+	'''
+
+	@Test(expected=Test.None /* no exception expected */)
+	def void issue30testMissingConnection() {
+		val testResult = issues = testHelper.testString(
+			com.rockwellcollins.atc.agree.tests.issues.Issue30Test.issue30TestMissingConnectionModel)
+
+		val topLevelImpl = EcoreUtil2.getAllContentsOfType(testResult.resource.contents.head, ComponentImplementation).
+			filter(
+				it |
+					"TopLevel.impl".equals(it.name)
+			).head
+		val instanceWithErrors = instantiateWithErrorMessages(topLevelImpl)
+		val errors = instanceWithErrors.value
+		Assert.assertTrue(errors.stream.anyMatch(msg|msg.message.contains("Could not continue connection from TopLevel_impl_Instance.sensors.temp.temp_reading ")))
+	}
+
+	// @Inject
+	// extension AssertHelper
+	static val issue30TestGoodConnectionModel = '''
 		package Issue30TestModel
 		public
 			with Base_Types;
@@ -112,17 +216,18 @@ class Issue30Test extends XtextTest {
 	'''
 
 	@Test(expected=Test.None /* no exception expected */)
-	def void issue30test1() {
+	def void issue30testGoodConnection() {
 		val testResult = issues = testHelper.testString(
-			com.rockwellcollins.atc.agree.tests.issues.Issue30Test.issue30TestModel)
+			com.rockwellcollins.atc.agree.tests.issues.Issue30Test.issue30TestGoodConnectionModel)
 
 		val topLevelImpl = EcoreUtil2.getAllContentsOfType(testResult.resource.contents.head, ComponentImplementation).
 			filter(
 				it |
 					"TopLevel.impl".equals(it.name)
 			).head
-		val componentInstance = InstantiateModel.instantiate(topLevelImpl)
-		new AgreeASTBuilder().getAgreeProgram(componentInstance, false)
+		val instanceWithErrors = instantiateWithErrorMessages(topLevelImpl)
+		val errors = instanceWithErrors.value
+		Assert.assertTrue(errors.empty)
 	}
 
 }


### PR DESCRIPTION
Implements traversing the connection instance model to formulate the logical connection assertions.  Accordingly, the connections are now derived consistently with the components.

A downside of this is that connection instances must terminate at an internal component or terminate at the top-level of the analysis.  To catch this, the AGREE analysis now checks that there are no such warnings at instantiation.

Traversing the connection instance model also has the benefit that it correctly handles connection patterns and is a necessary step to support issue #21.