### PR TITLE
Master issue 54

### DIFF
--- a/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/handlers/VerifyHandler.java
+++ b/com.rockwellcollins.atc.agree.analysis/src/com/rockwellcollins/atc/agree/analysis/handlers/VerifyHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -224,14 +223,6 @@ public abstract class VerifyHandler extends AadlHandler {
 
 			AnalysisResult result;
 			CompositeAnalysisResult wrapper = new CompositeAnalysisResult("");
-
-			ComponentType sysType = AgreeUtils.getInstanceType(si);
-			EList<AnnexSubclause> annexSubClauses = AnnexUtil.getAllAnnexSubclauses(sysType,
-					AgreePackage.eINSTANCE.getAgreeContractSubclause());
-
-			if (annexSubClauses.size() == 0) {
-				throw new AgreeException("There is not an AGREE annex in the '" + sysType.getName() + "' system type.");
-			}
 
 			if (isRecursive()) {
 				if (AgreeUtils.usingKind2()) {

--- a/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeJavaValidator.java
+++ b/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeJavaValidator.java
@@ -854,10 +854,13 @@ public class AgreeJavaValidator extends AbstractAgreeJavaValidator {
 					Set<String> usedChildInPorts = new HashSet<>();
 					Set<String> usedChildOutPorts = new HashSet<>();
 
+					EList<Classifier> ctPlusAllExtended = ct.getSelfPlusAllExtended();
+					EList<Classifier> subCtPlusAllExtended = subCt.getSelfPlusAllExtended();
+
 					for (Connection conn : ((ComponentImplementation) comp).getAllConnections()) {
 						{
 							NamedElement sourceNe = conn.getSource().getConnectionEnd();
-							if (sourceNe.getContainingClassifier() == subCt) {
+							if (subCtPlusAllExtended.contains(sourceNe.getContainingClassifier())) {
 
 								if (usedChildOutPorts.contains(sourceNe.getName())) {
 									error(lcst,
@@ -868,7 +871,7 @@ public class AgreeJavaValidator extends AbstractAgreeJavaValidator {
 								usedChildOutPorts.add(sourceNe.getName());
 							}
 
-							if (sourceNe.getContainingClassifier() == ct) {
+							if (ctPlusAllExtended.contains(sourceNe.getContainingClassifier())) {
 								if (usedParentInPorts.contains(sourceNe.getName())) {
 									error(lcst,
 											"'lift contract;' statement is not allowed in component implementation whith more than one connection out of same input "
@@ -883,7 +886,7 @@ public class AgreeJavaValidator extends AbstractAgreeJavaValidator {
 
 						{
 							NamedElement destNe = conn.getDestination().getConnectionEnd();
-							if (destNe.getContainingClassifier() == subCt) {
+							if (subCtPlusAllExtended.contains(destNe.getContainingClassifier())) {
 
 								if (usedChildInPorts.contains(destNe.getName())) {
 									error(lcst,
@@ -894,7 +897,7 @@ public class AgreeJavaValidator extends AbstractAgreeJavaValidator {
 								usedChildInPorts.add(destNe.getName());
 							}
 
-							if (destNe.getContainingClassifier() == ct) {
+							if (ctPlusAllExtended.contains(destNe.getContainingClassifier())) {
 
 								if (usedParentOutPorts.contains(destNe.getName())) {
 									error(lcst,


### PR DESCRIPTION
Add consideration of ports inherited from type extensions to validator port check for LiftContract statements

Remove over-zealous check for immediate annex in top-level type.

Resolves Issue #54