### PR TITLE
Issue 80 npe in named el validation

### DIFF
--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/AgreeLinkingTest.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/AgreeLinkingTest.xtend
@@ -671,7 +671,7 @@ class AgreeLinkingTest extends XtextTest {
               system TestSystem
                 annex agree {**
                   agree_input ain : int;
-                  assume "Input Assumption" : ain > 0;
+                  assume A1 "Input Assumption" : ain > 0;
                 **}; 
               end TestSystem;
             end TestPackage;
@@ -709,7 +709,7 @@ class AgreeLinkingTest extends XtextTest {
                 features
                   inp : in data port Base_Types::Integer;
                 annex agree {**
-                  assume "Input Assumption" : inp > 0;
+                  assume A1 "Input Assumption" : inp > 0;
                 **}; 
               end TestSystem;
             end TestPackage;
@@ -747,7 +747,7 @@ class AgreeLinkingTest extends XtextTest {
                 features
                   outp : out data port Base_Types::Integer;
                 annex agree {**
-                  guarantee "Output Guarantee" : outp > 0;
+                  guarantee G1 "Output Guarantee" : outp > 0;
                 **}; 
               end TestSystem;
             end TestPackage;
@@ -784,7 +784,7 @@ class AgreeLinkingTest extends XtextTest {
                 features
                   inp : in event port;
                 annex agree {**
-                  assume "Input Assumption" : event(inp);
+                  assume A1 "Input Assumption" : event(inp);
                 **}; 
               end TestSystem;
             end TestPackage;
@@ -821,7 +821,7 @@ class AgreeLinkingTest extends XtextTest {
                 features
                   outp : out event port;
                 annex agree {**
-                  guarantee "Output Guarantee" : event(outp);
+                  guarantee G1 "Output Guarantee" : event(outp);
                 **}; 
               end TestSystem;
             end TestPackage;
@@ -859,7 +859,7 @@ class AgreeLinkingTest extends XtextTest {
                 features
                   inp : in event data port Base_Types::Integer;
                 annex agree {**
-                  assume "Input Assumption" : inp > 0;
+                  assume A1 "Input Assumption" : inp > 0;
                 **}; 
               end TestSystem;
             end TestPackage;
@@ -897,7 +897,7 @@ class AgreeLinkingTest extends XtextTest {
                 features
                   outp : out event data port Base_Types::Integer;
                 annex agree {**
-                  guarantee "Output Guarantee" : outp > 0;
+                  guarantee G1 "Output Guarantee" : outp > 0;
                 **}; 
               end TestSystem;
             end TestPackage;
@@ -937,7 +937,7 @@ class AgreeLinkingTest extends XtextTest {
               end TestSystem;
               system implementation TestSystem.impl
                 annex agree {**
-                  lemma "Input Lemma" : ain > 0;
+                  lemma L1 "Input Lemma" : ain > 0;
                 **};
               end TestSystem.impl;
             end TestPackage;
@@ -976,7 +976,7 @@ class AgreeLinkingTest extends XtextTest {
                 features
                   inp : in data port Base_Types::Integer;
                 annex agree {**
-                  assume "Input Assumption" : inp > 0;
+                  assume A1 "Input Assumption" : inp > 0;
                 **}; 
               end TestSystem;
               system implementation TestSystem.impl
@@ -1017,7 +1017,7 @@ class AgreeLinkingTest extends XtextTest {
                 features
                   outp : out data port Base_Types::Integer;
                 annex agree {**
-                  guarantee "Output Guarantee" : outp > 0;
+                  guarantee G1 "Output Guarantee" : outp > 0;
                 **}; 
               end TestSystem;
               system implementation TestSystem.impl
@@ -1058,7 +1058,7 @@ class AgreeLinkingTest extends XtextTest {
                 features
                   outp : out data port Base_Types::Integer;
                 annex agree {**
-                  guarantee "Output Guarantee" : outp > 0;
+                  guarantee G1 "Output Guarantee" : outp > 0;
                 **}; 
               end TestSystem;
               system implementation TestSystem.impl
@@ -1098,7 +1098,7 @@ class AgreeLinkingTest extends XtextTest {
                   outp : out data port Base_Types::Integer;
                 annex agree {**
                   eq x : Base_Types::Integer;
-                  guarantee "Output Guarantee" : outp > x;
+                  guarantee G1 "Output Guarantee" : outp > x;
                 **}; 
               end TestSystem;
             end TestPackage;
@@ -1137,12 +1137,12 @@ class AgreeLinkingTest extends XtextTest {
                   outp : out data port Base_Types::Integer;
                 annex agree {**
                   eq x : Base_Types::Integer;
-                  guarantee "Output Guarantee" : outp > x;
+                  guarantee G1 "Output Guarantee" : outp > x;
                 **}; 
               end TestSystem;
               system implementation TestSystem.impl
                 annex agree {**
-                  lemma "Implementation Lemma" : x > 0;
+                  lemma L1 "Implementation Lemma" : x > 0;
                 **};
               end TestSystem.impl;
             end TestPackage;
@@ -1183,7 +1183,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Inner Output Guarantee" : outp > 0;
+                        guarantee G1 "Inner Output Guarantee" : outp > 0;
                     **};
                 end Inner;
                 system Outer
@@ -1191,7 +1191,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Outer Output Guarantee" : outp > 0;
+                        guarantee G1"Outer Output Guarantee" : outp > 0;
                     **};
                 end Outer;
                 system implementation Outer.impl
@@ -1201,7 +1201,7 @@ class AgreeLinkingTest extends XtextTest {
                         i1 : port inp -> inner_sub.inp;
                         o1 : port inner_sub.outp -> outp;
                     annex agree {**
-                        lemma "Outer Inner subcomponent lemma" : inner_sub.inp > 0;
+                        lemma L1 "Outer Inner subcomponent lemma" : inner_sub.inp > 0;
                     **};
                 end Outer.impl;
             end TestPackage;
@@ -1243,7 +1243,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Inner Output Guarantee" : outp > 0;
+                        guarantee G1"Inner Output Guarantee" : outp > 0;
                     **};
                 end Inner;
                 system Outer
@@ -1251,7 +1251,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Outer Output Guarantee" : outp > 0;
+                        guarantee G1 "Outer Output Guarantee" : outp > 0;
                     **};
                 end Outer;
                 system implementation Outer.impl
@@ -1261,7 +1261,7 @@ class AgreeLinkingTest extends XtextTest {
                         i1 : port inp -> inner_sub.inp;
                         o1 : port inner_sub.outp -> outp;
                     annex agree {**
-                        lemma "Outer Inner subcomponent lemma" : inner_sub.outp > 0;
+                        lemma L1 "Outer Inner subcomponent lemma" : inner_sub.outp > 0;
                     **};
                 end Outer.impl;
             end TestPackage;
@@ -1305,7 +1305,7 @@ class AgreeLinkingTest extends XtextTest {
                         outp : out data port Base_Types::Integer;
                     annex agree {**
                         type Coord3D = struct { x : int, y : int, z : int };
-                        guarantee "Inner Output Guarantee" : outp > 0;
+                        guarantee G1 "Inner Output Guarantee" : outp > 0;
                     **};
                 end Inner;
                 system Outer
@@ -1313,7 +1313,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Outer Output Guarantee" : outp > 0;
+                        guarantee G1 "Outer Output Guarantee" : outp > 0;
                     **};
                 end Outer;
                 system implementation Outer.impl
@@ -1324,7 +1324,7 @@ class AgreeLinkingTest extends XtextTest {
                         o1 : port inner_sub.outp -> outp;
                     annex agree {**
                         eq localCoord : Inner::Coord3D = Inner::Coord3D { x = 0; y = 0; z = 0 };
-                        lemma "Outer Inner subcomponent lemma" : inner_sub.inp > 0;
+                        lemma L1"Outer Inner subcomponent lemma" : inner_sub.inp > 0;
                     **};
                 end Outer.impl;
             end TestPackage;
@@ -1371,7 +1371,7 @@ class AgreeLinkingTest extends XtextTest {
                         outp : out data port Base_Types::Integer;
                     annex agree {**
                         const iconst : int = 10;
-                        guarantee "Inner Output Guarantee" : outp > 0;
+                        guarantee G1 "Inner Output Guarantee" : outp > 0;
                     **};
                 end Inner;
                 system Outer
@@ -1379,7 +1379,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Outer Output Guarantee" : outp > 0;
+                        guarantee G1 "Outer Output Guarantee" : outp > 0;
                     **};
                 end Outer;
                 system implementation Outer.impl
@@ -1389,7 +1389,7 @@ class AgreeLinkingTest extends XtextTest {
                         i1 : port inp -> inner_sub.inp;
                         o1 : port inner_sub.outp -> outp;
                     annex agree {**
-                        lemma "Outer Inner subcomponent lemma" : inner_sub.iconst > 0;
+                        lemma L1 "Outer Inner subcomponent lemma" : inner_sub.iconst > 0;
                     **};
                 end Outer.impl;
             end TestPackage;
@@ -1433,7 +1433,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Inner Output Guarantee" : outp > 0;
+                        guarantee G1 "Inner Output Guarantee" : outp > 0;
                     **};
                 end Inner;
                 system implementation Inner.impl
@@ -1446,7 +1446,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Outer Output Guarantee" : outp > 0;
+                        guarantee G1 "Outer Output Guarantee" : outp > 0;
                     **};
                 end Outer;
                 system implementation Outer.impl
@@ -1456,7 +1456,7 @@ class AgreeLinkingTest extends XtextTest {
                         i1 : port inp -> inner_sub.inp;
                         o1 : port inner_sub.outp -> outp;
                     annex agree {**
-                        lemma "Outer Inner subcomponent lemma" : inner_sub.iconst > 0;
+                        lemma L1 "Outer Inner subcomponent lemma" : inner_sub.iconst > 0;
                     **};
                 end Outer.impl;
             end TestPackage;
@@ -1501,7 +1501,7 @@ class AgreeLinkingTest extends XtextTest {
                         outp : out data port Base_Types::Integer;
                     annex agree {**
                         agree_input iinput : int;
-                        guarantee "Inner Output Guarantee" : outp > 0;
+                        guarantee G1 "Inner Output Guarantee" : outp > 0;
                     **};
                 end Inner;
                 system Outer
@@ -1509,7 +1509,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Outer Output Guarantee" : outp > 0;
+                        guarantee G1 "Outer Output Guarantee" : outp > 0;
                     **};
                 end Outer;
                 system implementation Outer.impl
@@ -1519,7 +1519,7 @@ class AgreeLinkingTest extends XtextTest {
                         i1 : port inp -> inner_sub.inp;
                         o1 : port inner_sub.outp -> outp;
                     annex agree {**
-                        lemma "Outer Inner subcomponent lemma" : inner_sub.iinput > 0;
+                        lemma L1 "Outer Inner subcomponent lemma" : inner_sub.iinput > 0;
                     **};
                 end Outer.impl;
             end TestPackage;
@@ -1564,7 +1564,7 @@ class AgreeLinkingTest extends XtextTest {
                         outp : out data port Base_Types::Integer;
                     annex agree {**
                         eq ivar : int = 10;
-                        guarantee "Inner Output Guarantee" : outp > 0;
+                        guarantee G1 "Inner Output Guarantee" : outp > 0;
                     **};
                 end Inner;
                 system Outer
@@ -1572,7 +1572,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Outer Output Guarantee" : outp > 0;
+                        guarantee G1 "Outer Output Guarantee" : outp > 0;
                     **};
                 end Outer;
                 system implementation Outer.impl
@@ -1582,7 +1582,7 @@ class AgreeLinkingTest extends XtextTest {
                         i1 : port inp -> inner_sub.inp;
                         o1 : port inner_sub.outp -> outp;
                     annex agree {**
-                        lemma "Outer Inner subcomponent lemma" : inner_sub.ivar > 0;
+                        lemma L1 "Outer Inner subcomponent lemma" : inner_sub.ivar > 0;
                     **};
                 end Outer.impl;
             end TestPackage;
@@ -1626,7 +1626,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Inner Output Guarantee" : outp > 0;
+                        guarantee G1 "Inner Output Guarantee" : outp > 0;
                     **};
                 end Inner;
                 system implementation Inner.impl
@@ -1639,7 +1639,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Outer Output Guarantee" : outp > 0;
+                        guarantee G1 "Outer Output Guarantee" : outp > 0;
                     **};
                 end Outer;
                 system implementation Outer.impl
@@ -1649,7 +1649,7 @@ class AgreeLinkingTest extends XtextTest {
                         i1 : port inp -> inner_sub.inp;
                         o1 : port inner_sub.outp -> outp;
                     annex agree {**
-                        lemma "Outer Inner subcomponent lemma" : inner_sub.ivar > 0;
+                        lemma L1 "Outer Inner subcomponent lemma" : inner_sub.ivar > 0;
                     **};
                 end Outer.impl;
             end TestPackage;
@@ -1694,7 +1694,7 @@ class AgreeLinkingTest extends XtextTest {
                         outp : out data port Base_Types::Integer;
                     annex agree {**
                         agree_input ivar : int;
-                        guarantee "Inner Output Guarantee" : outp > 0;
+                        guarantee G1 "Inner Output Guarantee" : outp > 0;
                     **};
                 end Inner;
                 system Outer
@@ -1702,7 +1702,7 @@ class AgreeLinkingTest extends XtextTest {
                         inp : in data port Base_Types::Integer;
                         outp : out data port Base_Types::Integer;
                     annex agree {**
-                        guarantee "Outer Output Guarantee" : outp > 0;
+                        guarantee G1 "Outer Output Guarantee" : outp > 0;
                     **};
                 end Outer;
                 system implementation Outer.impl
@@ -1712,7 +1712,7 @@ class AgreeLinkingTest extends XtextTest {
                         i1 : port inp -> inner_sub.inp;
                         o1 : port inner_sub.outp -> outp;
                     annex agree {**
-                        lemma "Outer Inner subcomponent lemma" : inner_sub.ivar > 0;
+                        lemma L1 "Outer Inner subcomponent lemma" : inner_sub.ivar > 0;
                     **};
                 end Outer.impl;
             end TestPackage;

--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/AgreeValidatorTest.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/AgreeValidatorTest.xtend
@@ -71,7 +71,7 @@ class AgreeValidatorTest extends XtextTest {
 				Input_Val: in data port Base_Types::Float;
 				Output_Val: out data port Base_Types::Float;
 			annex agree {**
-				assume "" : Input_Val < 20; -- should throw an error
+				assume A1 "" : Input_Val < 20; -- should throw an error
 			**};
 		end A;
 		
@@ -80,7 +80,7 @@ class AgreeValidatorTest extends XtextTest {
 				Input_Val: in data port Base_Types::Float;
 				Output_Val: out data port Base_Types::Float;
 			annex agree {**
-				assume "" : Input_Val < TEST_VAL;
+				assume A1 "" : Input_Val < TEST_VAL;
 			**};
 		end S;
 		

--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue17Test.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue17Test.xtend
@@ -176,7 +176,7 @@ class Issue17Test extends XtextTest {
 					sout : out event data port Charlie.impl;
 				annex agree {**
 					const id : Delta1.impl = 123456;
-					guarantee "sout id is set" : sout.id = id;
+					guarantee sout1 "sout id is set" : sout.id = id;
 				**};
 			end ScratchSys;
 		

--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue24Test.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue24Test.xtend
@@ -81,7 +81,7 @@ class Issue24Test extends XtextTest {
 					Input: refined to in data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 					Output: refined to out data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 				annex agree {**
-					assume "" : Input < 20;
+					assume A1 "" : Input < 20;
 				**};
 			end A_agree;
 		
@@ -90,7 +90,7 @@ class Issue24Test extends XtextTest {
 					Input: refined to in data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 					Output: refined to out data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 				annex agree {**
-					assume "" : Input < 10;
+					assume A1 "" : Input < 10;
 				**};
 			end S_agree;
 		
@@ -116,7 +116,7 @@ class Issue24Test extends XtextTest {
 					Input: in data port Base_Types::Integer;
 					Output: out data port Base_Types::Integer;
 				annex agree {**
-					assume "" : Input < 10;
+					assume A1 "" : Input < 10;
 				**};
 			end S_agree_new;
 		
@@ -168,13 +168,13 @@ class Issue24Test extends XtextTest {
 		
 			system A_agree extends A
 				annex agree {**
-					assume "" : Input < 20;
+					assume A1  "" : Input < 20;
 				**};
 			end A_agree;
 		
 			system S_agree extends S
 				annex agree {**
-					assume "" : Input < 10;
+					assume A1 "" : Input < 10;
 				**};
 			end S_agree;
 		
@@ -198,7 +198,7 @@ class Issue24Test extends XtextTest {
 					Input: in data port Base_Types::Integer;
 					Output: out data port Base_Types::Integer;
 				annex agree {**
-					assume "" : Input < 10;
+					assume A1 "" : Input < 10;
 				**};
 			end S_agree_new;
 		
@@ -262,7 +262,7 @@ class Issue24Test extends XtextTest {
 					Input: refined to in data port packet.impl {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 					Output: refined to out data port packet.impl {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 				annex agree {**
-					assume "" : Input.integer1 < 20;
+					assume A1 "" : Input.integer1 < 20;
 				**};
 			end A_agree;
 		
@@ -271,7 +271,7 @@ class Issue24Test extends XtextTest {
 					Input: refined to in data port packet.impl {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 					Output: refined to out data port packet.impl {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 				annex agree {**
-					assume "" : Input.integer1 < 10;
+					assume A1 "" : Input.integer1 < 10;
 				**};
 			end S_agree;
 		
@@ -297,7 +297,7 @@ class Issue24Test extends XtextTest {
 					Input: in data port packet.impl;
 					Output: out data port packet.impl;
 				annex agree {**
-					assume "" : Input.integer1 < 10;
+					assume A1 "" : Input.integer1 < 10;
 				**};
 			end S_agree_new;
 		
@@ -358,13 +358,13 @@ class Issue24Test extends XtextTest {
 		
 			system A_agree extends A
 				annex agree {**
-					assume "" : Input.integer1 < 20;
+					assume A1 "" : Input.integer1 < 20;
 				**};
 			end A_agree;
 		
 			system S_agree extends S
 				annex agree {**
-					assume "" : Input.integer1 < 10;
+					assume A1 "" : Input.integer1 < 10;
 				**};
 			end S_agree;
 		
@@ -388,7 +388,7 @@ class Issue24Test extends XtextTest {
 					Input: in data port packet.impl;
 					Output: out data port packet.impl;
 				annex agree {**
-					assume "" : Input.integer1 < 10;
+					assume A1 "" : Input.integer1 < 10;
 				**};
 			end S_agree_new;
 		
@@ -456,7 +456,7 @@ class Issue24Test extends XtextTest {
 					inp: refined to in data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 					outp: refined to out data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 				annex agree {**
-					assume "" : inp < 20;
+					assume A1 "" : inp < 20;
 				**};
 			end Inner_agree;
 		
@@ -465,7 +465,7 @@ class Issue24Test extends XtextTest {
 					inp: refined to in data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 					outp: refined to out data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 				annex agree {**
-					assume "" : inp < 15;
+					assume A1 "" : inp < 15;
 				**};
 			end Middle_agree;
 		
@@ -474,7 +474,7 @@ class Issue24Test extends XtextTest {
 					inp: refined to in data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 					outp: refined to out data port Base_Types::Integer {Classifier_Substitution_Rule => Type_Extension;}; -- refined type
 				annex agree {**
-					assume "" : inp < 10;
+					assume A1 "" : inp < 10;
 				**};
 			end Outer_agree;
 		
@@ -543,8 +543,8 @@ class Issue24Test extends XtextTest {
 					Input: refined to in data port packet_agree.impl {Classifier_Substitution_Rule => Type_Extension;};
 					Output: refined to out data port packet_agree.impl {Classifier_Substitution_Rule => Type_Extension;};
 				annex agree {**
-					assume "" : Input.foo < 20;
-					guarantee "" : Output.foo < 20;
+					assume A1 "" : Input.foo < 20;
+					guarantee G1 "" : Output.foo < 20;
 				**};
 			end A_agree;
 		
@@ -575,8 +575,8 @@ class Issue24Test extends XtextTest {
 					Input: refined to in data port packet_agree.impl {Classifier_Substitution_Rule => Type_Extension;};
 					Output: refined to out data port packet_agree.impl {Classifier_Substitution_Rule => Type_Extension;};
 				annex agree {**
-					assume "" : Input.foo < 10;
-					guarantee "" : Output.foo < 30;
+					assume A1 "" : Input.foo < 10;
+					guarantee G1 "" : Output.foo < 30;
 				**};
 			end S_agree;
 		

--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue30Test.xtend
@@ -71,10 +71,10 @@ class Issue30Test extends XtextTest {
 					temp_reading : out data port Integer;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						((env_temp > 0) and (env_temp < 10));
 		
-					guarantee "If temperature is high, output high indication.":
+					guarantee G1 "If temperature is high, output high indication.":
 						(((env_temp > 8) <=> high_temp_indicator) and (env_temp = temp_reading));
 				**};
 		
@@ -87,10 +87,10 @@ class Issue30Test extends XtextTest {
 					temp_high : out data port Boolean;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						((env_temp > 0) and (env_temp < 10));
 		
-					guarantee "Temperature guarantee.":
+					guarantee G1 "Temperature guarantee.":
 						(env_temp = temp_read) and ((env_temp > 8) <=> temp_high);
 				**};
 		
@@ -113,7 +113,7 @@ class Issue30Test extends XtextTest {
 					temp_sensor_high : out data port Boolean;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						(env_temp > 0) and (env_temp < 10);
 				**};
 			
@@ -128,7 +128,7 @@ class Issue30Test extends XtextTest {
 					temp_indicator : port sensors.temp_high -> temp_sensor_high;
 			
 				annex agree{**
-					lemma "The sensor only reports high when temp is actually high." :
+					lemma L1 "The sensor only reports high when temp is actually high." :
 						((env_temp > 8) <=> temp_sensor_high);
 				**};
 		
@@ -165,10 +165,10 @@ class Issue30Test extends XtextTest {
 					temp_reading : out data port Integer;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						((env_temp > 0) and (env_temp < 10));
 		
-					guarantee "If temperature is high, output high indication.":
+					guarantee G1 "If temperature is high, output high indication.":
 						(((env_temp > 8) <=> high_temp_indicator) and (env_temp = temp_reading));
 				**};
 		
@@ -181,10 +181,10 @@ class Issue30Test extends XtextTest {
 					temp_high : out data port Boolean;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						((env_temp > 0) and (env_temp < 10));
 		
-					guarantee "Temperature guarantee.":
+					guarantee G1 "Temperature guarantee.":
 						(env_temp = temp_read) and ((env_temp > 8) <=> temp_high);
 				**};
 		
@@ -208,7 +208,7 @@ class Issue30Test extends XtextTest {
 					temp_read : out data port Integer;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						(env_temp > 0) and (env_temp < 10);
 				**};
 			
@@ -224,7 +224,7 @@ class Issue30Test extends XtextTest {
 					temp_sensor_read : port sensors.temp_read -> temp_read;
 			
 				annex agree{**
-					lemma "The sensor only reports high when temp is actually high." :
+					lemma L1 "The sensor only reports high when temp is actually high." :
 						((env_temp > 8) <=> temp_sensor_high);
 				**};
 		
@@ -264,10 +264,10 @@ class Issue30Test extends XtextTest {
 					high_temp_indicator : out data port Boolean;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						((env_temp > 0) and (env_temp < 10));
 		
-					guarantee "If temperature is high, output high indication.":
+					guarantee G1 "If temperature is high, output high indication.":
 						((env_temp > 8) <=> high_temp_indicator);
 				**};
 		
@@ -284,10 +284,10 @@ class Issue30Test extends XtextTest {
 					temp_high : out data port Boolean;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						((env_temp > 0) and (env_temp < 10));
 		
-					guarantee "Temperature guarantee.":
+					guarantee G1 "Temperature guarantee.":
 						((env_temp > 8) <=> temp_high);
 				**};
 		
@@ -318,7 +318,7 @@ class Issue30Test extends XtextTest {
 					temp_sensor_high : out data port Boolean;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						(env_temp > 0) and (env_temp < 10);
 				**};
 			
@@ -333,7 +333,7 @@ class Issue30Test extends XtextTest {
 					temp_indicator : port sensors.temp_high -> temp_sensor_high;
 			
 				annex agree{**
-					lemma "The sensor only reports high when temp is actually high." :
+					lemma L1 "The sensor only reports high when temp is actually high." :
 						((env_temp > 8) <=> temp_sensor_high);
 				**};
 		
@@ -374,10 +374,10 @@ class Issue30Test extends XtextTest {
 					high_temp_indicator : out data port Boolean;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						((env_temp > 0) and (env_temp < 10));
 		
-					guarantee "If temperature is high, output high indication.":
+					guarantee G1 "If temperature is high, output high indication.":
 						((env_temp > 8) <=> high_temp_indicator);
 				**};
 		
@@ -389,10 +389,10 @@ class Issue30Test extends XtextTest {
 					temp_high : out data port Boolean;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						((env_temp > 0) and (env_temp < 10));
 		
-					guarantee "Temperature guarantee.":
+					guarantee G1 "Temperature guarantee.":
 						((env_temp > 8) <=> temp_high);
 				**};
 		
@@ -417,7 +417,7 @@ class Issue30Test extends XtextTest {
 					temp_sensor_high : out data port Boolean;
 			
 				annex agree {**
-					assume "Temp bounded":
+					assume A1 "Temp bounded":
 						(env_temp > 0) and (env_temp < 10);
 				**};
 			
@@ -432,7 +432,7 @@ class Issue30Test extends XtextTest {
 					temp_indicator : port sensors.temp_high -> temp_sensor_high;
 			
 				annex agree{**
-					lemma "The sensor only reports high when temp is actually high." :
+					lemma L1 "The sensor only reports high when temp is actually high." :
 						((env_temp > 8) <=> temp_sensor_high);
 				**};
 		

--- a/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue31Test.xtend
+++ b/com.rockwellcollins.atc.agree.tests/src/com/rockwellcollins/atc/agree/tests/issues/Issue31Test.xtend
@@ -127,13 +127,13 @@ class Issue31Test extends XtextTest {
 					Output : out data port H2I.impl;
 				annex agree {**
 		
-					guarantee "Respond to message that Sensor1 is unreliable":
+					guarantee G1 "Respond to message that Sensor1 is unreliable":
 						prev(not InputFromIAS.Sensor1_Reliable, false) <=> ((Output.Sensor1_Unreliable_Response = enum(Response, Agree)) or (Output.Sensor1_Unreliable_Response = enum(Response, Disagree))); 
 		
-					guarantee "Respond to message that Sensor2 is unreliable":
+					guarantee G2 "Respond to message that Sensor2 is unreliable":
 						prev(not InputFromIAS.Sensor2_Reliable, false) <=> ((Output.Sensor2_Unreliable_Response = enum(Response, Agree)) or (Output.Sensor2_Unreliable_Response = enum(Response, Disagree)));
 		
-					guarantee "Respond to message that Sensor3 is unreliable":
+					guarantee G3 "Respond to message that Sensor3 is unreliable":
 						prev(not InputFromIAS.Sensor2_Reliable, false) <=> ((Output.Sensor3_Unreliable_Response = enum(Response, Agree)) or (Output.Sensor3_Unreliable_Response = enum(Response, Disagree)));		
 		
 				**};
@@ -157,7 +157,7 @@ class Issue31Test extends XtextTest {
 					eq Sensor2_Reliable: bool;
 					eq Sensor3_Reliable: bool;
 		
-					guarantee "Sensor sensor status to pilot":
+					guarantee G1 "Sensor sensor status to pilot":
 							(Output.Sensor1_Reliable = Sensor1_Reliable)
 						and (Output.Sensor2_Reliable = Sensor2_Reliable)
 						and (Output.Sensor3_Reliable = Sensor3_Reliable);
@@ -191,7 +191,7 @@ class Issue31Test extends XtextTest {
 		
 			system Top
 				annex agree {**
-					guarantee "Placeholder gaurantee to get AGREE to run": true;
+					guarantee G0 "Placeholder gaurantee to get AGREE to run": true;
 				**};
 			end Top;
 		
@@ -217,7 +217,7 @@ class Issue31Test extends XtextTest {
 					-- LEMMAS (These should be true based on the guarantees of the subcomponents.)
 					------------------------------------------------------------------------------
 		
-					lemma "Pilot acknowledges unreliable sensor alerts": 
+					lemma L1 "Pilot acknowledges unreliable sensor alerts": 
 							(prev(not IAS.Output.Sensor1_Reliable, false) <=> ((Human.Output.Sensor1_Unreliable_Response = enum(Response, Agree)) or (Human.Output.Sensor1_Unreliable_Response = enum(Response, Disagree))))
 						and (prev(not IAS.Output.Sensor2_Reliable, false) <=> ((Human.Output.Sensor2_Unreliable_Response = enum(Response, Agree)) or (Human.Output.Sensor2_Unreliable_Response = enum(Response, Disagree))))
 						and (prev(not IAS.Output.Sensor3_Reliable, false) <=> ((Human.Output.Sensor3_Unreliable_Response = enum(Response, Agree)) or (Human.Output.Sensor3_Unreliable_Response = enum(Response, Disagree))));

--- a/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeValidator.java
+++ b/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeValidator.java
@@ -1960,7 +1960,7 @@ public class AgreeValidator extends AbstractAgreeValidator {
 			type = (ComponentType) container;
 		}
 
-		if (type != null) {
+		if (type != null && (namedEl.getName() != null)) {
 			for (Feature feat : type.getAllFeatures()) {
 				if (namedEl.getName().equals(feat.getName())) {
 					error(feat, "Element of the same name ('" + namedEl.getName() + "') in AGREE Annex in '"

--- a/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeValidator.java
+++ b/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/validation/AgreeValidator.java
@@ -139,6 +139,7 @@ import com.rockwellcollins.atc.agree.agree.PreExpr;
 import com.rockwellcollins.atc.agree.agree.PrevExpr;
 import com.rockwellcollins.atc.agree.agree.PrimType;
 import com.rockwellcollins.atc.agree.agree.PropertyStatement;
+import com.rockwellcollins.atc.agree.agree.ReachableStatement;
 import com.rockwellcollins.atc.agree.agree.RealCast;
 import com.rockwellcollins.atc.agree.agree.RealLitExpr;
 import com.rockwellcollins.atc.agree.agree.RecordDef;
@@ -828,6 +829,12 @@ public class AgreeValidator extends AbstractAgreeValidator {
 						+ "' but must be of type 'bool'");
 			}
 		}
+
+		if (assume.getName() == null) {
+			info(assume, "It is recommended that assume statements be named."
+					+ " (Hint: an identifier may be placed between the \"assume\" keyword and the quoted description.)");
+		}
+
 	}
 
 	@Check(CheckType.FAST)
@@ -1033,6 +1040,10 @@ public class AgreeValidator extends AbstractAgreeValidator {
 				+ "assertions are realizable.  It is likely that you can specify the "
 				+ "behavior you want by changing the subcomponent contracts or " + "by using assignment statements.");
 
+		if (asser.getName() == null) {
+			info(asser, "It is recommended that assert statements be named."
+					+ " (Hint: an identifier may be placed between the \"assert\" keyword and the quoted description.)");
+		}
 	}
 
 	@Check(CheckType.FAST)
@@ -1074,6 +1085,34 @@ public class AgreeValidator extends AbstractAgreeValidator {
 				error(guar, "Expression for guarantee statement is of type '" + nameOfTypeDef(exprType)
 						+ "' but must be of type 'bool'");
 			}
+		}
+
+		if (guar.getName() == null) {
+			info(guar, "It is recommended that guarantee statements be named."
+					+ " (Hint: an identifier may be placed between the \"guarantee\" keyword and the quoted description.)");
+		}
+	}
+
+	@Check(CheckType.FAST)
+	public void checkReachable(ReachableStatement reachable) {
+		Classifier comp = reachable.getContainingClassifier();
+		if (!(comp instanceof ComponentImplementation)) {
+			error(reachable, "Reachable statements are allowed only in component implementations");
+		}
+
+		// the expression could be null if a pattern is used
+		Expr expr = reachable.getExpr();
+		if (expr != null) {
+			TypeDef exprType = AgreeTypeSystem.infer(expr);
+			if (!AgreeTypeSystem.typesEqual(AgreeTypeSystem.Prim.BoolTypeDef, exprType)) {
+				error(reachable, "Expression for reachable statement is of type '" + nameOfTypeDef(exprType)
+						+ "' but must be of type 'bool'");
+			}
+		}
+
+		if (reachable.getName() == null) {
+			info(reachable, "It is recommended that reachable statements be named."
+					+ " (Hint: an identifier may be placed between the \"reachable\" keyword and the quoted description.)");
 		}
 	}
 
@@ -1387,6 +1426,11 @@ public class AgreeValidator extends AbstractAgreeValidator {
 				error(lemma, "Expression for lemma statement is of type '" + nameOfTypeDef(exprType)
 						+ "' but must be of type 'bool'");
 			}
+		}
+
+		if (lemma.getName() == null) {
+			info(lemma, "It is recommended that lemma statements be named."
+					+ " (Hint: an identifier may be placed between the \"lemma\" keyword and the quoted description.)");
 		}
 	}
 


### PR DESCRIPTION
Resolves #80 

-  Fix NPE by checking that named elements have non-null name before comparing with other names
-  Adds validation that raises info message for unnamed specification statements and recommends naming them
-  Updates tests by adding names to specification statements such that there are no raised issues