### PR TITLE
Fix ClassCastException scoping DoubeDotRef

### DIFF
--- a/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/scoping/AgreeScopeProvider.java
+++ b/com.rockwellcollins.atc.agree/src/com/rockwellcollins/atc/agree/scoping/AgreeScopeProvider.java
@@ -502,7 +502,7 @@ public class AgreeScopeProvider extends org.osate.xtext.aadl2.properties.scoping
 	protected IScope scope_DoubleDotRef_elm(DoubleDotRef ctx, EReference ref) {
 
 		IScope prevScope = prevScope(ctx, ref);
-		EObject container = ((GetPropertyExpr) ctx.eContainer()).getContainingComponentImpl();
+		EObject container = ctx.getContainingComponentImpl();
 		if (container instanceof ComponentImplementation) {
 			return Scopes.scopeFor(((ComponentImplementation) ctx).getAllSubcomponents(), prevScope);
 		}


### PR DESCRIPTION
Fix class cast exception by moving to impl scope from any type of container.

Resolves #96.